### PR TITLE
Fix Razor component references for .NET 9

### DIFF
--- a/src/EsgAsAService.Web/Components/Layout/MainLayout.razor
+++ b/src/EsgAsAService.Web/Components/Layout/MainLayout.razor
@@ -1,3 +1,4 @@
+@using EsgAsAService.Web.Components.Shared
 @inherits LayoutComponentBase
 
 <div class="app-shell">

--- a/src/EsgAsAService.Web/Components/Layout/NavMenu.razor
+++ b/src/EsgAsAService.Web/Components/Layout/NavMenu.razor
@@ -19,14 +19,14 @@
         </NavLink>
     </div>
 
-    @foreach (var section in _sections)
+    @foreach (var menuSection in _sections)
     {
         <div class="nav-section">
-            <div class="nav-title" title="@section.Description">
-                <span class="bi @section.Icon me-2"></span>@section.Title
+            <div class="nav-title" title="@menuSection.Description">
+                <span class="bi @menuSection.Icon me-2"></span>@menuSection.Title
             </div>
             <ul class="nav-list">
-                @foreach (var item in section.Items)
+                @foreach (var item in menuSection.Items)
                 {
                     if (!item.RequiresAuthentication)
                     {

--- a/src/EsgAsAService.Web/Components/Shared/ToastContainer.razor
+++ b/src/EsgAsAService.Web/Components/Shared/ToastContainer.razor
@@ -9,7 +9,7 @@
         <div class="toast show mb-2" role="status" aria-live="assertive" aria-atomic="true">
             <div class="toast-header">
                 <strong class="me-auto">@toast.Title</strong>
-                <small>@toast.CreatedAt.ToLocalTime().ToShortTimeString()</small>
+                <small>@toast.CreatedAt.ToLocalTime().ToString("t")</small>
                 <button type="button" class="btn-close" @onclick="() => Close(toast)"></button>
             </div>
             <div class="toast-body">


### PR DESCRIPTION
## Summary
- import the shared components namespace in the main layout so diagnostic and error components resolve
- rename the navigation loop variable to avoid Razor treating `@section` as a directive
- format toast timestamps with `ToString("t")` to replace the unavailable `ToShortTimeString`

## Testing
- ⚠️ `DOTNET_ROLL_FORWARD=Major dotnet build src/EsgAsAService.Web` *(fails: `dotnet` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5353687ec8325a316898d28cdaae7